### PR TITLE
feat: add openapi_kit crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,11 +224,18 @@ version = "0.1.0"
 
 [[package]]
 name = "openapi_generator"
-version = "0.1.0"
+version = "0.0.1"
+
+[[package]]
+name = "openapi_kit"
+version = "0.0.1"
+dependencies = [
+ "openapi_macros",
+]
 
 [[package]]
 name = "openapi_macros"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "handlebars",
  "openapi_schema",
@@ -236,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "openapi_schema"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "openapiv3",
  "serde_yaml",

--- a/crates/libs/openapi_kit/Cargo.toml
+++ b/crates/libs/openapi_kit/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "openapi_kit"
+description = "OpenAPI Kit"
+version = "0.0.1"
+edition = "2024"
+homepage = "github.com/netrune/openapi"
+repository = "github.com/netrune/openapi"
+readme = "README.md"
+license = "MIT"
+
+[dependencies]
+openapi_macros.workspace = true

--- a/crates/libs/openapi_kit/README.md
+++ b/crates/libs/openapi_kit/README.md
@@ -1,0 +1,3 @@
+# OpenAPI Kit
+
+### A kit to make working with OpenAPI a breeze

--- a/crates/libs/openapi_kit/src/lib.rs
+++ b/crates/libs/openapi_kit/src/lib.rs
@@ -1,0 +1,5 @@
+pub use openapi_macros as macros;
+
+pub mod prelude {
+    pub use crate::macros::*;
+}


### PR DESCRIPTION
This PR adds the `openapi_kit` crate, which will work as a common interface to most internal `openapi_*` crates in this cargo workspace.

As of this PR, only openapi_macros will be exposed through this interface.