### PR TITLE
feat: remove `openapi!` macro, and introduce `from_file!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ version = "0.0.1"
 dependencies = [
  "handlebars",
  "openapi_kit_schema",
+ "syn",
 ]
 
 [[package]]

--- a/crates/libs/openapi_kit/src/lib.rs
+++ b/crates/libs/openapi_kit/src/lib.rs
@@ -1,7 +1,6 @@
-pub use openapi_kit_macros as macros;
 pub use openapi_kit_schema as schema;
 
-pub mod prelude {
-    pub use crate::macros::*;
-    pub use crate::schema::*;
+// All modules related to generating code from OpenAPI schema files
+pub mod generate {
+    pub use openapi_kit_macros::from_file;
 }

--- a/crates/libs/openapi_kit_macros/Cargo.toml
+++ b/crates/libs/openapi_kit_macros/Cargo.toml
@@ -12,5 +12,7 @@ license = "MIT"
 openapi_kit_schema.workspace = true
 handlebars.workspace = true
 
+syn = { version = "2.0.98" }
+
 [lib]
 proc-macro = true

--- a/crates/libs/openapi_kit_macros/src/generate_from_file.rs
+++ b/crates/libs/openapi_kit_macros/src/generate_from_file.rs
@@ -1,0 +1,58 @@
+use std::fs::read_to_string;
+
+use handlebars::Handlebars;
+use proc_macro::TokenStream;
+use syn::{LitStr, Token, parse::Parse, parse_macro_input};
+
+pub fn parse(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as FromFileArgs);
+
+    let Ok(content) = read_to_string(args.template.value()) else {
+        panic!("Failed to read file");
+    };
+
+    let schema_path = args
+        .schema
+        .map(|s| s.value())
+        .unwrap_or(String::from("openapi.yaml"));
+
+    let Ok(schema) = openapi_kit_schema::load(schema_path.as_ref()) else {
+        panic!("Failed to load schema at {}", schema_path);
+    };
+
+    // Render the template
+    let hbs = Handlebars::new();
+    let Ok(output) = hbs.render_template(&content, &schema) else {
+        panic!("Failed to render template");
+    };
+
+    // Return as a string literal
+    let Ok(parsed) = output.parse() else {
+        panic!("Failed to parse output");
+    };
+
+    parsed
+}
+
+struct FromFileArgs {
+    template: LitStr,
+    schema: Option<LitStr>,
+}
+
+impl Parse for FromFileArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let template = input.parse()?;
+        let schema = if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            input.parse()?
+        } else {
+            None
+        };
+
+        if !input.is_empty() {
+            return Err(input.error("unexpected token"));
+        }
+
+        Ok(FromFileArgs { template, schema })
+    }
+}

--- a/crates/libs/openapi_kit_macros/src/lib.rs
+++ b/crates/libs/openapi_kit_macros/src/lib.rs
@@ -2,6 +2,8 @@ mod generate_from_file;
 
 use proc_macro::TokenStream;
 
+/// Generate code from a template file
+///
 #[proc_macro]
 pub fn from_file(input: TokenStream) -> TokenStream {
     generate_from_file::parse(input)

--- a/crates/libs/openapi_kit_macros/src/lib.rs
+++ b/crates/libs/openapi_kit_macros/src/lib.rs
@@ -1,39 +1,8 @@
-#![feature(proc_macro_span)]
+mod generate_from_file;
+
 use proc_macro::TokenStream;
 
-use handlebars::Handlebars;
-
 #[proc_macro]
-pub fn openapi(input: TokenStream) -> TokenStream {
-    let tokens: Vec<_> = input.into_iter().collect();
-
-    // Get spans of the first and last tokens
-    let Some(first_span) = tokens.first().map(|t| t.span()) else {
-        return TokenStream::new();
-    };
-    let Some(last_span) = tokens.last().map(|t| t.span()) else {
-        return TokenStream::new();
-    };
-
-    // Join spans to get the full range
-    let Some(combined_span) = first_span.join(last_span) else {
-        return TokenStream::new();
-    };
-
-    // Extract raw source code between the spans
-    let Some(source) = combined_span.source_text() else {
-        return TokenStream::new();
-    };
-
-    // Load OpenAPI schema
-    let schema = openapi_kit_schema::load("openapi.yaml");
-
-    // Render the template
-    let hbs = Handlebars::new();
-    let Ok(output) = hbs.render_template(&source, &schema) else {
-        return TokenStream::new();
-    };
-
-    // Return as a string literal
-    output.parse().unwrap()
+pub fn from_file(input: TokenStream) -> TokenStream {
+    generate_from_file::parse(input)
 }

--- a/crates/libs/openapi_kit_schema/src/lib.rs
+++ b/crates/libs/openapi_kit_schema/src/lib.rs
@@ -1,6 +1,11 @@
 pub type OpenApiSchema = openapiv3::OpenAPI;
 
-pub fn load(path: &str) -> OpenApiSchema {
-    let file = std::fs::read_to_string(path).unwrap();
-    serde_yaml::from_str(&file).unwrap()
+pub enum Error {
+    Io(std::io::Error),
+    Serde(serde_yaml::Error),
+}
+
+pub fn load(path: &str) -> Result<OpenApiSchema, Error> {
+    let file = std::fs::read_to_string(path).map_err(|e| Error::Io(e))?;
+    serde_yaml::from_str(&file).map_err(|e| Error::Serde(e))
 }


### PR DESCRIPTION
This PR practically removes the `openapi!` macro from the codebase, and introduces a new macro `from_file!`.

**Why?**
`openapi!` relied on unstable features from the nightly build of rust. As a crate published on crates.io, this is not desirable.
There were also tons of bugs I head to deal with regarding parsing input in the macro to retain whitespace (which incidentally turned out to be impossible). The `from_file!` macro takes a different approach, where the path to a template is passed in instead, which is then loaded and ran through the renderer. An additional argument can be passed to the macro in order to specify which schema is to be read. By default, it looks for "openapi.yaml" in the project root.

> [!WARNING]
> The signature of the `from_file!` macro is unstable, and subject to change in the future.