### PR TITLE
feat(workspace): add Workspace struct and support for loading the Workspace root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "openapi_kit_workspace"
+version = "0.0.1"
+
+[[package]]
 name = "openapiv3"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/libs/openapi_kit_workspace/Cargo.toml
+++ b/crates/libs/openapi_kit_workspace/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "openapi_kit_workspace"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]

--- a/crates/libs/openapi_kit_workspace/src/error.rs
+++ b/crates/libs/openapi_kit_workspace/src/error.rs
@@ -1,0 +1,24 @@
+use std::fmt::Display;
+
+#[derive(Debug)]
+pub enum Error {
+    IO(std::io::Error),
+    NoWorkspaceFound,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::IO(error) => f.write_str(error.to_string().as_str()),
+            Error::NoWorkspaceFound => f.write_str("No workspace found"),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Error::IO(value)
+    }
+}
+
+impl std::error::Error for Error {}

--- a/crates/libs/openapi_kit_workspace/src/lib.rs
+++ b/crates/libs/openapi_kit_workspace/src/lib.rs
@@ -1,0 +1,5 @@
+mod error;
+mod workspace;
+
+pub use error::Error;
+pub use workspace::Workspace;

--- a/crates/libs/openapi_kit_workspace/src/workspace.rs
+++ b/crates/libs/openapi_kit_workspace/src/workspace.rs
@@ -1,0 +1,32 @@
+use crate::error::Error;
+use std::path::{Path, PathBuf};
+
+pub struct Workspace {
+    pub path: PathBuf,
+}
+
+impl Workspace {
+    pub fn load() -> Result<Self, Error> {
+        let current_dir = std::env::current_dir()?;
+        Self::load_recursive(current_dir)
+    }
+
+    /// Recursively look for a ".openapi" directory to mark the root directory of the workspace.
+    ///
+    fn load_recursive<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let path = path.as_ref();
+        let full_path = path.join(".openapi");
+
+        if !full_path.exists() {
+            let Some(parent) = path.parent() else {
+                return Err(Error::NoWorkspaceFound);
+            };
+
+            Self::load_recursive(parent)
+        } else {
+            Ok(Workspace {
+                path: path.to_path_buf(),
+            })
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new crate `openapi_kit_workspace`. This crate will hold everything related to an _openapi workspace_.

> [!WARNING]
> There is a difference between an OpenAPI Workspace, and a Cargo Workspace

An OpenAPI Workspace is defined as the directory where a `.openapi` directory can be found. The structure of the `.openapi` directory will be implemented in future  PRs. The goal of the directory is to mark a fixed point in a file system where configuration files and templates may reside, and in some cases it will make it easier to refer to resolve files.