### PR TITLE
chore: update to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ version = "0.1.0"
 
 [[package]]
 name = "openapi_kit"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "openapi_kit_macros",
  "openapi_kit_schema",
@@ -236,7 +236,7 @@ version = "0.0.1"
 
 [[package]]
 name = "openapi_kit_macros"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "handlebars",
  "openapi_kit_schema",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "openapi_kit_schema"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "openapiv3",
  "serde_yaml",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "openapi_kit_workspace"
-version = "0.0.1"
+version = "0.0.3"
 
 [[package]]
 name = "openapiv3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ resolver = "2"
 members = ["crates/apps/*", "crates/libs/*"]
 
 [workspace.dependencies]
-openapi_kit_workspace = { version = "0.0.1", path = "crates/libs/openapi_kit_workspace" }
-openapi_kit_schema = { version = "0.0.1", path = "crates/libs/openapi_kit_schema" }
-openapi_kit_macros = { version = "0.0.1", path = "crates/libs/openapi_kit_macros" }
+openapi_kit_workspace = { version = "0.0.3", path = "crates/libs/openapi_kit_workspace" }
+openapi_kit_schema = { version = "0.0.3", path = "crates/libs/openapi_kit_schema" }
+openapi_kit_macros = { version = "0.0.3", path = "crates/libs/openapi_kit_macros" }
 
 openapiv3 = { version = "2.0.0" }
 handlebars = { version = "6.3.1" }

--- a/crates/libs/openapi_kit/Cargo.toml
+++ b/crates/libs/openapi_kit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openapi_kit"
 description = "OpenAPI Kit"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 homepage = "https://github.com/netrune/openapi"
 repository = "https://github.com/netrune/openapi"

--- a/crates/libs/openapi_kit_macros/Cargo.toml
+++ b/crates/libs/openapi_kit_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openapi_kit_macros"
 description = "OpenAPI Macros"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 homepage = "https://github.com/netrune/openapi"
 repository = "https://github.com/netrune/openapi"

--- a/crates/libs/openapi_kit_schema/Cargo.toml
+++ b/crates/libs/openapi_kit_schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openapi_kit_schema"
 description = "OpenAPI Schema"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 homepage = "https://github.com/netrune/openapi"
 repository = "https://github.com/netrune/openapi"

--- a/crates/libs/openapi_kit_workspace/Cargo.toml
+++ b/crates/libs/openapi_kit_workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openapi_kit_workspace"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
This PR bumps all relevant versions to 0.0.3 before releasing to crates.io.