### PR TITLE
feat(macros): set .openapi as path origin

### DIFF
--- a/crates/libs/openapi_kit_macros/src/generate.rs
+++ b/crates/libs/openapi_kit_macros/src/generate.rs
@@ -11,8 +11,8 @@ pub fn from_file(path: &str) -> TokenStream {
 
     let path = workspace.path.join(".openapi").join(path);
 
-    let Ok(content) = read_to_string(path) else {
-        panic!("Failed to read file");
+    let Ok(content) = read_to_string(&path) else {
+        panic!("Failed to read file at {}", path.display());
     };
 
     generate(content.as_str(), workspace)

--- a/crates/libs/openapi_kit_macros/src/generate.rs
+++ b/crates/libs/openapi_kit_macros/src/generate.rs
@@ -9,6 +9,8 @@ pub fn from_file(path: &str) -> TokenStream {
         panic!("Could not load workspace");
     };
 
+    let path = workspace.path.join(".openapi").join(path);
+
     let Ok(content) = read_to_string(path) else {
         panic!("Failed to read file");
     };


### PR DESCRIPTION
This PR makes sure that macros start at the resolved `.openapi` directory when constructing a path to the template file.