### PR TITLE
chore: update to v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ version = "0.1.0"
 
 [[package]]
 name = "openapi_kit"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "openapi_kit_macros",
  "openapi_kit_schema",
@@ -236,7 +236,7 @@ version = "0.0.1"
 
 [[package]]
 name = "openapi_kit_macros"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "handlebars",
  "openapi_kit_schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/apps/*", "crates/libs/*"]
 [workspace.dependencies]
 openapi_kit_workspace = { version = "0.0.3", path = "crates/libs/openapi_kit_workspace" }
 openapi_kit_schema = { version = "0.0.3", path = "crates/libs/openapi_kit_schema" }
-openapi_kit_macros = { version = "0.0.3", path = "crates/libs/openapi_kit_macros" }
+openapi_kit_macros = { version = "0.0.4", path = "crates/libs/openapi_kit_macros" }
 
 openapiv3 = { version = "2.0.0" }
 handlebars = { version = "6.3.1" }

--- a/crates/libs/openapi_kit/Cargo.toml
+++ b/crates/libs/openapi_kit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openapi_kit"
 description = "OpenAPI Kit"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 homepage = "https://github.com/netrune/openapi"
 repository = "https://github.com/netrune/openapi"

--- a/crates/libs/openapi_kit_macros/Cargo.toml
+++ b/crates/libs/openapi_kit_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openapi_kit_macros"
 description = "OpenAPI Macros"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 homepage = "https://github.com/netrune/openapi"
 repository = "https://github.com/netrune/openapi"


### PR DESCRIPTION
This PR updates Cargo.toml to version 0.0.4 before publishing.