### PR TITLE
feat(workspace): parse Config as part of Workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +192,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +271,10 @@ dependencies = [
 [[package]]
 name = "openapi_kit_workspace"
 version = "0.0.3"
+dependencies = [
+ "serde",
+ "serde_yml",
+]
 
 [[package]]
 name = "openapiv3"
@@ -379,6 +399,21 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ openapi_kit_macros = { version = "0.0.4", path = "crates/libs/openapi_kit_macros
 
 openapiv3 = { version = "2.0.0" }
 handlebars = { version = "6.3.1" }
+serde_yml = { version = "0.0.12" }
+serde = { version = "1.0.218", features = ["derive"] }

--- a/crates/libs/openapi_kit_workspace/Cargo.toml
+++ b/crates/libs/openapi_kit_workspace/Cargo.toml
@@ -9,3 +9,5 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
+serde.workspace = true
+serde_yml.workspace = true

--- a/crates/libs/openapi_kit_workspace/src/config.rs
+++ b/crates/libs/openapi_kit_workspace/src/config.rs
@@ -1,0 +1,30 @@
+use std::{collections::HashMap, fs::File, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Config {
+    pub projects: HashMap<String, Project>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Project {
+    pub language: String,
+    pub templates: HashMap<String, Template>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Template {
+    pub path: String,
+}
+
+impl Config {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        let config = serde_yml::from_reader(file)?;
+
+        Ok(config)
+    }
+}

--- a/crates/libs/openapi_kit_workspace/src/error.rs
+++ b/crates/libs/openapi_kit_workspace/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 #[derive(Debug)]
 pub enum Error {
     IO(std::io::Error),
+    InvalidConfig(serde_yml::Error),
     NoWorkspaceFound,
 }
 
@@ -11,6 +12,7 @@ impl Display for Error {
         match self {
             Error::IO(error) => f.write_str(error.to_string().as_str()),
             Error::NoWorkspaceFound => f.write_str("No workspace found"),
+            Error::InvalidConfig(error) => f.write_str(error.to_string().as_str()),
         }
     }
 }
@@ -18,6 +20,12 @@ impl Display for Error {
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
         Error::IO(value)
+    }
+}
+
+impl From<serde_yml::Error> for Error {
+    fn from(value: serde_yml::Error) -> Self {
+        Error::InvalidConfig(value)
     }
 }
 

--- a/crates/libs/openapi_kit_workspace/src/lib.rs
+++ b/crates/libs/openapi_kit_workspace/src/lib.rs
@@ -1,3 +1,4 @@
+mod config;
 mod error;
 mod workspace;
 

--- a/crates/libs/openapi_kit_workspace/src/workspace.rs
+++ b/crates/libs/openapi_kit_workspace/src/workspace.rs
@@ -1,8 +1,9 @@
-use crate::error::Error;
+use crate::{config::Config, error::Error};
 use std::path::{Path, PathBuf};
 
 pub struct Workspace {
     pub path: PathBuf,
+    pub config: Config,
 }
 
 impl Workspace {
@@ -24,9 +25,10 @@ impl Workspace {
 
             Self::load_recursive(parent)
         } else {
-            Ok(Workspace {
-                path: path.to_path_buf(),
-            })
+            let path = path.to_path_buf();
+            let config = Config::load(full_path.join("config.yaml"))?;
+
+            Ok(Workspace { path, config })
         }
     }
 }


### PR DESCRIPTION
This PR calls `Config::load()` in the `Workspace::load` function as soon as the Workspace has been found. A config file is now required. If the file is not found, `Workspace::load` will fail. 