### PR TITLE
feat: deprecate all other generative macros, introduce `generate!` macro

### DIFF
--- a/crates/libs/openapi_kit/src/lib.rs
+++ b/crates/libs/openapi_kit/src/lib.rs
@@ -1,9 +1,2 @@
-pub use openapi_kit_macros::generate_from_file as from_file;
-pub use openapi_kit_macros::generate_from_template as from_template;
+pub use openapi_kit_macros::generate;
 pub use openapi_kit_schema as schema;
-
-// All modules related to generating code from OpenAPI schema files
-pub mod generate {
-    pub use super::from_file;
-    pub use super::from_template;
-}

--- a/crates/libs/openapi_kit_macros/src/generate.rs
+++ b/crates/libs/openapi_kit_macros/src/generate.rs
@@ -3,30 +3,34 @@ use std::fs::read_to_string;
 use handlebars::Handlebars;
 use openapi_kit_workspace::Workspace;
 use proc_macro::TokenStream;
+use syn::{Error, LitStr, parse::Parse, parse_macro_input, spanned::Spanned};
 
-pub fn from_file(path: &str) -> TokenStream {
-    let Ok(workspace) = Workspace::load() else {
-        panic!("Could not load workspace");
+pub fn from_project(input: TokenStream) -> TokenStream {
+    // Parse into tokens to a Reference.
+    let reference = parse_macro_input!(input as Reference);
+
+    // Load nearest Workspace.
+    let workspace = match Workspace::load() {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            panic!("{error}");
+        }
     };
 
-    let path = workspace.path.join(".openapi").join(path);
-
-    let Ok(content) = read_to_string(&path) else {
-        panic!("Failed to read file at {}", path.display());
+    // Retrieve project and template from Config.
+    let Some(project) = workspace.config.projects.get(&reference.project) else {
+        panic!("Could not find project");
+    };
+    let Some(template) = project.templates.get(&reference.template) else {
+        panic!("Could not find template");
     };
 
-    generate(content.as_str(), workspace)
-}
-
-pub fn from_template(template: &str) -> TokenStream {
-    let Ok(workspace) = Workspace::load() else {
-        panic!("Could not load workspace");
+    // Retrieve template contents from path.
+    let template_path = workspace.path.join(".openapi").join(&template.path);
+    let Ok(template_content) = read_to_string(&template_path) else {
+        panic!("Failed to read file at {}", template_path.display());
     };
 
-    generate(template, workspace)
-}
-
-fn generate(template: &str, workspace: Workspace) -> TokenStream {
     // Set fallback for schema path, and load the schema
     let schema_path = workspace.path.join("openapi.yaml");
     let Ok(schema) = openapi_kit_schema::load(&schema_path) else {
@@ -35,7 +39,7 @@ fn generate(template: &str, workspace: Workspace) -> TokenStream {
 
     // Render the template
     let hbs = Handlebars::new();
-    let Ok(output) = hbs.render_template(&template, &schema) else {
+    let Ok(output) = hbs.render_template(&template_content, &schema) else {
         panic!("Failed to render template");
     };
 
@@ -45,4 +49,39 @@ fn generate(template: &str, workspace: Workspace) -> TokenStream {
     };
 
     parsed
+}
+
+/// A Reference to the project and template.
+///
+struct Reference {
+    project: String,
+    template: String,
+}
+
+impl Parse for Reference {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // Parse input to a literal string
+        let input = input.parse::<LitStr>()?.value();
+
+        // Split string based on colon.
+        let Some((project, template)) = input.split_once(":") else {
+            return Err(Error::new(
+                input.span(),
+                "Expected pattern <project>:<template>",
+            ));
+        };
+
+        // Ensure project and template references are not empty
+        if project == "" {
+            return Err(Error::new(input.span(), "Project name can not be empty"));
+        }
+        if template == "" {
+            return Err(Error::new(input.span(), "Template name can not be empty"));
+        }
+
+        Ok(Reference {
+            project: String::from(project),
+            template: String::from(template),
+        })
+    }
 }

--- a/crates/libs/openapi_kit_macros/src/lib.rs
+++ b/crates/libs/openapi_kit_macros/src/lib.rs
@@ -1,20 +1,8 @@
 mod generate;
 
 use proc_macro::TokenStream;
-use syn::{LitStr, parse_macro_input};
 
-/// Generate code from a file
-///
 #[proc_macro]
-pub fn generate_from_file(input: TokenStream) -> TokenStream {
-    let path = parse_macro_input!(input as LitStr).value();
-    generate::from_file(path.as_str())
-}
-
-/// Generate code from a string
-///
-#[proc_macro]
-pub fn generate_from_template(input: TokenStream) -> TokenStream {
-    let template = parse_macro_input!(input as LitStr).value();
-    generate::from_template(template.as_str())
+pub fn generate(input: TokenStream) -> TokenStream {
+    generate::from_project(input)
 }


### PR DESCRIPTION
This PR deprecates all other generative macros, such as `from_file!` and `from_template!`.
Instead, `openapi_kit_macros` now exposes one proc_macro: `generate!`, which takes a string with the pattern `<project>:<template>`. This macro will look up the config under the `.openapi` directory, and find configuration for the template under the provided project. This will give access to languages for translation in the template between OpenAPI types and any target language (in most cases, rust).